### PR TITLE
add error frame handling on frame serialize and connection

### DIFF
--- a/lib/rsocket/connection.rb
+++ b/lib/rsocket/connection.rb
@@ -36,8 +36,12 @@ module RSocket
           receive_setup(frame)
         when :REQUEST_RESPONSE, :REQUEST_FNF, :REQUEST_STREAM, :REQUEST_CHANNEL, :METADATA_PUSH
           receive_request(frame)
-        when :PAYLOAD, :ERROR
+        when :PAYLOAD
           receive_response(frame)
+        when :ERROR
+          if defined?(error_handler)
+            error_handler(frame)
+          end
         when :CANCEL
           # cancel logic
         when :REQUEST_N

--- a/lib/rsocket/frame.rb
+++ b/lib/rsocket/frame.rb
@@ -86,6 +86,8 @@ module RSocket
         frame = PayloadFrame.new(stream_id, flags)
       when :METADATA_PUSH
         frame = MetadataPushFrame.new
+      when :ERROR
+        frame = ErrorFrame.new(stream_id)
       else
         # type code here
       end


### PR DESCRIPTION
**Patch to handle Error Frames**

- Logic to create new Error Frame if appropriate on frame.rb parse
- Added Error Frame check on connection.rb receive_frame_bytes  and a call to error_handler if defined
